### PR TITLE
[hotfix] Если в поле установлено значение и оно proxy - то не считать это пустым значением и не пытаться подменить (вместо этого проверять его).

### DIFF
--- a/Dac/EventSubscriber.php
+++ b/Dac/EventSubscriber.php
@@ -182,7 +182,6 @@ class EventSubscriber implements EventSubscriberInterface
                 ($originalValue instanceof Collection)
                 && (0 === $originalValue->count())
             )
-            || ($originalValue instanceof DoctrineProxy)
         );
     }
 


### PR DESCRIPTION
Нужно для https://maxposter.myjetbrains.com/youtrack/issue/max-5444